### PR TITLE
store: modular backends (sqlite + memory) and README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,796 +1,94 @@
 <div align="center">
+  <a href="https://github.com/ogkae/yurei/fork"><img width="460" alt="banner" src="https://github.com/user-attachments/assets/5dc7c238-f972-4d0e-887a-78eff2492356"/></a>
 
-<a href="https://github.com/ogkae/yurei/fork"><img width="460" height="353" alt="banner" src="https://github.com/user-attachments/assets/5dc7c238-f972-4d0e-887a-78eff2492356"/></a> 
+  **yurei** · librería python sin dependencias externas para utilidades criptográficas prácticas.
 
-|[![Version](https://img.shields.io/badge/version-1.4.1-9b87f5?style=for-the-badge&logo=python)](https://github.com/ogkae/yurei) [![Python](https://img.shields.io/badge/python-3.10+-9b87f5?style=for-the-badge&logo=python)](https://www.python.org) [![License](https://img.shields.io/badge/license-MIT-9b87f5?style=for-the-badge)](./LICENSE) [![Stars](https://img.shields.io/github/stars/ogkae/yurei?style=for-the-badge&color=9b87f5)](https://github.com/ogkae/yurei/stargazers) |
-|----|
-
-*Lightweight cryptographic primitives for modern Python applications.*
-
+  [![Version](https://img.shields.io/badge/version-1.4.1-9b87f5?style=for-the-badge&logo=python)](https://github.com/ogkae/yurei)
+  [![Python](https://img.shields.io/badge/python-3.10+-9b87f5?style=for-the-badge&logo=python)](https://www.python.org)
+  [![License](https://img.shields.io/badge/license-MIT-9b87f5?style=for-the-badge)](./LICENSE)
 </div>
 
----
+## por qué yurei
 
-## Table of Contents
+- **simple**: api pequeña y directa.
+- **modular**: cada módulo cubre una responsabilidad.
+- **portable**: solo usa `stdlib`.
+- **robusta para tooling interno**: validaciones explícitas y fallos seguros.
 
-- [**Table of contents**](#table-of-contents)
-- [Overview](#overview)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [What's New in v1.4.1](#whats-new-in-v141)
-- [API Reference:](#api-reference)
-  - [`uid` - Identifier Generation](#uid---identifier-generation)
-  - [`auth` - Password Hashing](#auth---password-hashing)
-  - [`session` - Token Management](#session---token-management)
-  - [`cipher` - Encryption](#cipher---encryption)
-  - [`store` - Key-Value Storage](#store---key-value-storage)
-  - [`obfusc` - XOR Obfuscation](#obfusc---xor-obfuscation)
-- [Security Considerations](#security-considerations)
-- [Contributing](#contributing)
----
+> ⚠️ para producción sensible, usa librerías auditadas como `cryptography` con aes-gcm o chacha20-poly1305.
 
-## Overview
-
-Yurei provides **cryptographic utilities without external dependencies**, built entirely on Python's standard library. Designed for **rapid prototyping**, **internal tooling**, and **environments with restricted package installation**.
-
-<details>
-<summary><b><code>Quick Example</code></b></summary>
-
-```python
-from yurei import encrypt_bytes, create_token, hash_password
-
-# - generate signed tokens with expiration -
-token = create_token({"user": "alice"}, b"secret", ttl_seconds=3600)
-
-# - encrypt sensitive data -
-encrypted = encrypt_bytes(b"confidential", b"passphrase")
-
-# - hash passwords securely -
-pwd_hash = hash_password("SecurePass123")
-```
-
-</details>
-
-> [!WARNING]
-> **For production systems**, prefer audited cryptographic libraries such as [`cryptography`](https://cryptography.io/) with [`AES-GCM`](https://datatracker.ietf.org/doc/html/rfc5288) or [`ChaCha20-Poly1305`](https://datatracker.ietf.org/doc/html/rfc7539). Yurei is optimised for development and internal use cases.
-
-### Architecture
-
-```mermaid
-graph TB
-    A[Application Layer] --> B[yurei Core API]
-    B --> C[uid<br/>Identifiers]
-    B --> D[auth<br/>Passwords]
-    B --> E[session<br/>Tokens]
-    B --> F[cipher<br/>Encryption]
-    B --> G[store<br/>Persistence]
-    B --> H[obfusc<br/>XOR]
-    
-    style B fill:#9b87f5,stroke:#7b6dd5,color:#fff
-    style C fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style D fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style E fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style F fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style G fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style H fill:#1e1e2e,stroke:#9b87f5,color:#fff
-```
-
-### Core Modules
-
-| <code>Module</code> | <code>Purpose</code> | <code>Implementation</code> |
-|:------:|:--------|:---------------|
-| **uid** | Unique identifier generation | SHA256, CSPRNG |
-| **auth** | Password hashing with salts | PBKDF2-HMAC-SHA256 (200k iterations) |
-| **session** | Signed tokens with expiration | HMAC-SHA256 |
-| **cipher** | Authenticated encryption | HMAC-based stream cipher |
-| **store** | Key-value persistence | SQLite WAL mode, JSON serialisation |
-| **obfusc** | XOR obfuscation | XOR + Base64 encoding |
-
-```diff
- Ideal For
-+ Environments with strict dependency constraints
-+ Educational projects and cryptography learning
-+ Internal tooling and automation scripts
-+ Rapid prototyping and MVPs
-  -----------------------
- Not Suitable For
-- Compliance-regulated applications (PCI-DSS, HIPAA, GDPR)
-- Applications requiring cryptographic certifications
-- High-security environments requiring formal audits
-- Production systems handling sensitive data
-```
-
----
-
-## Installation
-
-```ini
-[Requirements]
-dependencies   = none (stdlib only)
-python_version = 3.10+
-```
+## instalación
 
 ```bash
-$ git clone https://github.com/ogkae/yurei
-$ pip install -e .
-$ cd yurei
+pip install -e .
 ```
 
-<details>
-<summary><b><code>Alternative Installation Methods</code></b></summary>
-
-**From Source**
-```bash
-$ python setup.py install
-```
-
-**Development Mode with Testing Tools**
-```bash
-$ pip install -e ".[dev]"
-```
-
-</details>
-
----
-
-## Quick Start
+## quick start
 
 ```python
 from yurei import (
-    uuid4, hash_password, verify_password,
-    encrypt_bytes, decrypt_bytes,
+    uuid4,
+    hash_password, verify_password,
     create_token, verify_token,
-    KVStore
+    encrypt_bytes, decrypt_bytes,
+    KVStore,
 )
-
 import os
 
-# - generate unique identifiers -
-user_id = uuid4()
-print(f"User ID: {user_id}")
-
-# - hash and verify passwords -
-pwd_hash = hash_password("SecurePass123")
-is_valid = verify_password(pwd_hash, "SecurePass123")
-print(f"Password valid: {is_valid}")
-
-# - create and verify signed tokens -
-secret = os.urandom(32)
-token = create_token(
-    {"uid": user_id, "role": "admin"}, 
-    secret, 
-    ttl_seconds=3600
-)
-payload = verify_token(token, secret)
-print(f"Token payload: {payload}")
-
-# - encrypt and decrypt data -
-encrypted = encrypt_bytes(b"sensitive data", b"strong-passphrase")
-decrypted = decrypt_bytes(encrypted, b"strong-passphrase")
-print(f"Decrypted: {decrypted.decode()}")
-
-# - persistent key-value storage -
-with KVStore("data.db") as db:
-    db.set("user:session", {"uid": user_id, "active": True})
-    session = db.get("user:session")
-    print(f"Session: {session}")
-```
-
----
-
-## What's New in v1.4.1
-
-Version 1.4.1 represents a **comprehensive enhancement release that strengthens Yurei's foundation across all modules**. This update delivers significant performance **improvements**, **robust security hardening**, and an **expanded feature set with over 15 new functions**, while **maintaining complete backward compatibility with version 1.4.0**.
-
-# New Features
-
-```mermaid
-graph LR
-    A[v1.4.1 Features] --> B[Identifier Generation]
-    A --> C[Authentication]
-    A --> D[Session Management]
-    A --> E[Storage]
-    A --> F[Obfuscation]
-    A --> G[Cryptographic Utilities]
-    
-    B --> B1[nanoid]
-    B --> B2[ulid]
-    B --> B3[secure_token]
-    
-    C --> C1[validate_password_strength]
-    
-    D --> D1[refresh_token]
-    
-    E --> E1[keys with prefix]
-    E --> E2[clear bulk delete]
-    E --> E3[get with default]
-    
-    F --> F1[rot13]
-    F --> F2[caesar_cipher]
-    F --> F3[base64 utilities]
-    
-    G --> G1[secure_zero]
-    G --> G2[hkdf_extract]
-    
-    style A fill:#9b87f5,stroke:#7b6dd5,color:#fff
-    style B fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style C fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style D fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style E fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style F fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style G fill:#1e1e2e,stroke:#9b87f5,color:#fff
-```
-
-<details>
-  <summary><b><code>Full Changes</code></b></summary>
-
-#### Identifier Generation
-
-**New ID formats** provide flexible options for different use cases. The `nanoid()` function generates compact 21-character URL-safe identifiers with high entropy, ideal for public-facing IDs. The `ulid()` function creates timestamp-sortable identifiers that maintain lexicographic ordering while providing randomness. For high-security scenarios, `secure_token()` generates cryptographically strong tokens suitable for API keys and reset tokens.
-
-**Enhanced HMAC IDs** now support both hexadecimal and base64 output formats through the `hex_output` parameter, providing flexibility in how identifiers are represented.
-
-#### Authentication & Sessions
-
-**Password strength validation** arrives with `validate_password_strength()`, enabling policy enforcement before hashing. The function checks for minimum length, character diversity, and returns detailed feedback on any issues.
-
-**Token refresh capability** through `refresh_token()` allows extending token lifetimes without re-authentication, essential for implementing "remember me" functionality and activity-based session extensions.
-
-#### Storage Enhancements
-
-**Key management** becomes more powerful with `keys()` for listing stored keys with optional prefix filtering, running 38% faster than manual iteration. The `clear()` method enables efficient bulk deletions with optional prefix matching.
-
-**Graceful defaults** via enhanced `get()` method prevent exception handling overhead by returning user-specified default values for missing keys.
-
-#### Obfuscation & Utilities
-
-**Classical ciphers** expand the obfuscation toolkit with `rot13()` for self-inverse transformation and `caesar_cipher()` with configurable shift values. Simplified `base64_encode()` and `base64_decode()` wrappers provide convenience utilities.
-
-**Memory safety** introduces `secure_zero()` for wiping sensitive data from memory, and `hkdf_extract()` exposes the HKDF extract step for advanced key derivation workflows.
-
-</details>
-
----
-
-## API Reference
-
-### uid - Identifier Generation
-
-Secure generation of unique identifiers for various use cases.
-
-```python
-from yurei import uuid4, is_uuid4, sha256_id, short_id
-
-# - generate cryptographically secure UUID4
-user_id = uuid4()
-# Returns: "550e8400-e29b-41d4-a716-446655440000"
-
-# - validate UUID4 format
-is_valid = is_uuid4(user_id)
-# Returns: True
-
-# - create deterministic SHA256-based identifier
-doc_id = sha256_id("documents", "invoice-2024", salt="secret")
-# Returns: 64-character hexadecimal string
-
-# - generate short URL-safe token
-token = short_id(length=12)
-# Returns: "aB3xK9mP2nQ1"
-```
-
-<details>
-<summary><b><code>Technical Specifications</code></b></summary>
-
-```ini
-[UUID4]
-source      = os.urandom (system CSPRNG)
-format      = RFC 4122 compliant
-entropy     = 122 bits
-  -----------------------
-[SHA256 ID]
-input       = concatenated arguments + optional salt
-output      = 64-character hex string (256 bits)
-algorithm   = SHA256
-  -----------------------
-[Short ID]
-charset     = alphanumeric (a-z, A-Z, 0-9)
-length      = configurable (default: 12)
-entropy     = ~71 bits (length=12)
-```
-
-</details>
-
-```diff
-+ Deterministic reproducibility (SHA256-based IDs)
-+ Cryptographically secure random generation
-+ Customisable token lengths
-+ URL-safe character sets
-```
-
----
-
-### auth - Password Hashing
-
-Industry-standard password hashing with automatic salt generation.
-
-```python
-from yurei import hash_password, verify_password
-
-# - hash a password
-pwd_hash = hash_password("SecurePass123", iterations=200_000)
-# Returns: "pbkdf2$200000$<salt_b64>$<hash_b64>"
-
-# - verify password against hash
-is_valid = verify_password(pwd_hash, "SecurePass123")
-# Returns: True
-
-is_valid = verify_password(pwd_hash, "WrongPassword")
-# Returns: False
-```
-
-<details>
-<summary><b><code>Security Features</code></b></summary>
-
-```ini
-[Algorithm]
-iterations     = 200,000 (default, configurable)
-salt_length    = 16 bytes (128 bits)
-output_length  = 32 bytes (256 bits)
-kdf            = PBKDF2-HMAC-SHA256
-  -----------------------
-[Protection]
-timing_attacks = constant-time comparison (hmac.compare_digest)
-rainbow_tables = random salt per password
-dictionary     = high iteration count
-```
-
-</details>
-
-```diff
-+ Constant-time comparison (prevents timing attacks)
-+ Random salts (prevents rainbow table attacks)
-+ Configurable iterations (future-proof against hardware advances)
-+ Standard PBKDF2-HMAC-SHA256 (widely audited)
-```
-
----
-
-### session - Token Management
-
-Generate and verify signed tokens with automatic expiration handling.
-
-```python
-from yurei import create_token, verify_token
-import os
+uid = uuid4()
+pwd = hash_password("SecurePass123!")
+assert verify_password(pwd, "SecurePass123!")
 
 secret = os.urandom(32)
+token = create_token({"uid": uid, "role": "admin"}, secret, ttl_seconds=3600)
+assert verify_token(token, secret) is not None
 
-# - create signed token with payload -
-token = create_token( 
-    payload={"uid": "user123", "role": "admin"},
-    secret=secret,
-    ttl_seconds=3600  # 1 hour expiration
-)
-# Returns: "<payload_b64>.<signature_b64>"
+blob = encrypt_bytes(b"payload", b"passphrase-fuerte")
+assert decrypt_bytes(blob, b"passphrase-fuerte") == b"payload"
 
-# - verify and extract payload -
-payload = verify_token(token, secret)
-# Returns: {"uid": "user123", "role": "admin"}
-# Returns: None if invalid or expired
-```
-
-<details>
-<summary><b><code>Token Format Specification</code></b></summary>
-
-**Structure:**
-```
-<base64url(json_payload)>.<base64url(hmac_signature)>
-```
-
-**Example:**
-```
-eyJ1aWQiOiJ1c2VyMTIzIiwiZXhwIjoxNzM1MDAwMDAwfQ.a8f3KmN9pQ2xR5tY7uI1oP3sK6vL4wM
-```
-
-**Payload Contents:**
-```json
-{
-  "uid": "user123",
-  "role": "admin",
-  "exp": 1735000000  // Unix timestamp (automatically added)
-}
-```
-
-```ini
-[Signature]
-output       = 32 bytes, base64url encoded
-verification = constant-time comparison
-input        = base64url(json_payload)
-algorithm    = HMAC-SHA256
-```
-
-</details>
-
-```diff
-+ HMAC-SHA256 signature verification
-+ Automatic expiration handling
-+ JSON payload serialisation
-+ URL-safe base64 encoding
-```
-
----
-
-### cipher - Encryption
-
-Authenticated encryption with support for parallel processing of large files.
-
-#### Basic Encryption
-
-```python
-from yurei import encrypt_bytes, decrypt_bytes
-
-plaintext = b"Sensitive information"
-key = b"my-secure-passphrase"  # (any length accepted)
-
-# - encrypt data -
-encrypted = encrypt_bytes(plaintext, key)
-# Returns: base64url(salt + nonce + ciphertext + mac)
-
-# - decrypt data -
-decrypted = decrypt_bytes(encrypted, key)
-# Returns: b"Sensitive information"
-# Raises: ValueError if MAC verification fails
-```
-
-#### Parallel Encryption
-
-For large files, parallel processing significantly improves performance.
-
-```python
-from yurei import encrypt_parallel, decrypt_parallel
-
-# - read large file -
-with open("large_file.bin", "rb") as f:
-    plaintext = f.read()
-
-# - encrypt using multiple workers -
-encrypted = encrypt_parallel(
-    plaintext=plaintext,
-    key=b"my-secure-key",
-    chunk_size=1024*1024,  # 1 MB chunks
-    workers=4              # CPU cores to utilise
-)
-
-# - decrypt using parallel processing -
-decrypted = decrypt_parallel(
-    encrypted, 
-    key=b"my-secure-key", 
-    workers=4
-)
-```
-
-```mermaid
-graph TB
-    EB[Encrypted Blob] --> S[Salt<br/>16 bytes<br/>PBKDF2 input]
-    EB --> N[Nonce<br/>12 bytes<br/>Stream cipher IV]
-    EB --> C[Ciphertext<br/>Variable length<br/>Encrypted data]
-    EB --> M[MAC Tag<br/>32 bytes<br/>HMAC-SHA256]
-
-    style EB fill:#9b87f5,stroke:#7b6dd5,color:#fff
-    style S fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style N fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style C fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style M fill:#1e1e2e,stroke:#9b87f5,color:#fff
-```
-
-```ini
-[Key Derivation]
-stage_1    = PBKDF2-HMAC-SHA256 (100k iterations)
-stage_2    = HKDF-SHA256 (key expansion)
-salt       = 16 bytes random (per encryption)
-output     = 64 bytes (encryption key + MAC key)
-  -----------------------
-[Encryption]
-scheme     = HMAC-based PRF stream cipher
-mode       = Encrypt-then-MAC
-nonce      = 12 bytes random (per encryption)
-block_size = 64 bytes
-  -----------------------
-[Authentication]
-mac           = HMAC-SHA256
-input         = salt + nonce + ciphertext
-output        = 32 bytes
-verification  = constant-time comparison
-```
-
-```diff
- Authenticated encryption (Encrypt-then-MAC)
-+ Key derivation from arbitrary-length passphrases
-+ Parallel processing support (large files)
-+ Random salt and nonce per encryption
-+ Constant-time MAC verification
-  -----------------------
- Custom stream cipher (not AES-GCM/ChaCha20-Poly1305)
-- No formal security audit
-- Not suitable for high-security environments
-```
-
----
-
-### store - Key-Value Storage
-
-Simple persistent storage with SQLite backend or in-memory operation.
-
-```python
-from yurei import KVStore
-
-# - inmemory storage (no persistence) -
-db = KVStore()
-
-# - SQLite-backed storage (persisted to disk) -
-db = KVStore("data.db")
-
-# - store data (automatic JSON serialisation) -
-db.set("user:123", {"name": "Alice", "email": "alice@example.com"})
-
-# - retrieve data -
-user = db.get("user:123")
-# Returns: {"name": "Alice", "email": "alice@example.com"}
-
-missing = db.get("user:999")
-# Returns: None
-
-# - check existence -
-exists = db.exists("user:123")
-# Returns: True
-
-# - delete data -
-db.delete("user:123")
-
-# - context manager (automatic cleanup) -
 with KVStore("data.db") as db:
-    db.set("key", {"value": "data"})
-    # Automatically closed after block
+    db.set("user:1", {"uid": uid})
+    print(db.get("user:1"))
 ```
 
-<details>
-<summary><b><code>Storage Backend Details</code></b></summary>
+## módulos
 
-```ini
-[SQLite Configuration]
-journal_mode = WAL (Write-Ahead Logging)
-synchronous  = NORMAL
-temp_store   = MEMORY
-  -----------------------
-[Schema]
-columns   = key TEXT PRIMARY KEY, value TEXT
-index     = PRIMARY KEY on key
-encoding  = JSON serialisation
-table     = kv_store
-  -----------------------
-[Operations]
-get       = O(log n) with B-tree index
-set       = O(log n) with WAL buffering
-delete    = O(log n)
-exists    = O(log n)
+| módulo | objetivo | funciones clave |
+|---|---|---|
+| `uid` | ids y tokens | `uuid4`, `short_id`, `sha256_id` |
+| `auth` | hashing de contraseñas | `hash_password`, `verify_password` |
+| `session` | tokens firmados con ttl | `create_token`, `verify_token` |
+| `cipher` | cifrado autenticado ligero | `encrypt_bytes`, `decrypt_bytes` |
+| `store` | persistencia kv | `KVStore` |
+| `obfusc` | ofuscación básica | `xor_obfuscate`, `xor_deobfuscate` |
+
+## diseño interno (v1.4.1)
+
+- `store` ahora usa **backends pluggables** (`in-memory` y `sqlite`) para crecer sin romper la api pública.
+- separación clara entre capa pública (`KVStore`) y capa interna (`_store_backends`).
+- estructura preparada para añadir nuevos backends (ej: redis) manteniendo el mismo contrato.
+
+## hecho por zektrace
+
+```text
+<< 匿名性の最大の利点は、あなたが匿名であることだ >>
+welcome to my profile
 ```
-
-</details>
-
-```diff
-+ Automatic JSON serialisation/deserialisation
-+ SQLite WAL mode (concurrent reads)
-+ In-memory mode available (no I/O overhead)
-+ Context manager support (automatic cleanup)
-```
-
----
-
-### obfusc - XOR Obfuscation
-
-> [!WARNING]
-> **Not cryptographically secure.** XOR obfuscation provides **zero protection** against determined attackers. Use only for non-security purposes.
-
-```python
-from yurei import xor_obfuscate, xor_deobfuscate
-
-original = "Sensitive text"
-key = "secret-key"
-
-# - obfuscate string -
-obfuscated = xor_obfuscate(original, key)
-# Returns: base64-encoded XOR result
-
-# - deobfuscate string -
-restored = xor_deobfuscate(obfuscated, key)
-# Returns: "Sensitive text"
-```
-
-<details>
-<summary><b><code>Technical Details</code></b></summary>
-
-```ini
-[Algorithm]
-operation = XOR (bitwise exclusive OR)
-encoding  = base64 (output encoding)
-key       = repeating key stream
-  -----------------------
-[Security]
-integrity      = no authentication/tampering detection
-key_secrecy    = does not provide confidentiality
-strength       = none (trivially reversible)
-```
-
-**How It Works:**
-```
-plaintext:  "HELLO"
-key:        "KEY" (repeating)
-XOR result: [binary data]
-output:     base64(XOR result)
-```
-
-</details>
-
-```diff
- Appropriate Use Cases
-+ Deterring casual inspection of configuration files
-+ Obfuscating hardcoded strings in source code
-+ Basic data mangling for non-security purposes
-+ Lightweight encoding/decoding without dependencies
-  -----------------------
- Inappropriate Use Cases
-- Protecting passwords or credentials
-- Encrypting sensitive personal data
-- Authentication tokens or session identifiers
-- Any security-critical application
-- Protection against skilled attackers
-```
-
----
-
-## Security Considerations
-
-### Cryptographic Architecture
-
-```mermaid
-graph TB
-    A[Application Layer] --> B[yurei API]
-    B --> C[Key Derivation<br/>PBKDF2 + HKDF]
-    B --> D[Authentication<br/>HMAC-SHA256]
-    B --> E[Encryption<br/>Stream Cipher]
-    C --> F[Python stdlib<br/>hashlib + hmac]
-    D --> F
-    E --> F
-    
-    style B fill:#9b87f5,stroke:#7b6dd5,color:#fff
-    style C fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style D fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style E fill:#1e1e2e,stroke:#9b87f5,color:#fff
-    style F fill:#2a2a3e,stroke:#9b87f5,color:#fff
-```
-
-### Cryptographic Primitives
-
-| Component | Algorithm | Parameters | Standard |
-|:----------|:----------|:-----------|:---------|
-| **Password KDF** | PBKDF2-HMAC-SHA256 | 200k iterations, 16B salt, 32B output | NIST SP 800-132 |
-| **Encryption KDF** | PBKDF2 + HKDF | 100k iterations, key expansion | NIST SP 800-108 |
-| **MAC** | HMAC-SHA256 | 32B output, constant-time verify | FIPS 198-1 |
-| **Cipher** | HMAC-based PRF stream | 12B nonce, Encrypt-then-MAC | Custom design |
-| **CSPRNG** | `os.urandom` | System entropy source | Platform-dependent |
-
-<details>
-<summary><b><code>Security Strengths</code></b></summary>
-
-```diff
-+ Uses well-established primitives (PBKDF2, HMAC, SHA256)
-+ Constant-time comparison for MAC/password verification
-+ Random salts and nonces prevent replay attacks
-+ High iteration counts resist brute-force attacks
-+ Encrypt-then-MAC construction (recommended pattern)
-+ No external dependencies (reduced supply chain risk)
-```
-
-</details>
-
-<details>
-<summary><b><code>Security Limitations</code></b></summary>
-
-```diff
-- Custom stream cipher (not AES-GCM or ChaCha20-Poly1305)
-- No formal security audit or peer review
-- No side-channel attack analysis
-- Limited cryptanalysis compared to standard algorithms
-- Not suitable for compliance-regulated environments
-- Cannot guarantee security against nation-state adversaries
-```
-
-</details>
-
-### Alternative Solutions
-
-For production environments, consider these audited alternatives:
-
-| <code>Library</code> | <code>Algorithm</code> | <code>Use Case</code> |
-|:--------|:----------|:---------|
-| [`cryptography`](https://cryptography.io/) | AES-GCM, ChaCha20-Poly1305 | General-purpose encryption |
-| [`bcrypt`](https://github.com/pyca/bcrypt/) | bcrypt | Password hashing |
-| [`PyNaCl`](https://pynacl.readthedocs.io/) | NaCl/libsodium | High-level cryptography API |
-| [`argon2-cffi`](https://github.com/hynek/argon2-cffi) | Argon2 | Modern password hashing |
-
----
-
-## Contributing
-
-**Contributions are welcome!** Please review the [<code>CONTRIBUTING.md</code>](./CONTRIBUTING.md) guidelines before submitting.
-
-### Priority Development Areas
-
-| <code>Area</code> | <code>Description</code> | <code>Skills Required</code> |
-|:-----|:------------|:----------------|
-| **Test Coverage** | Comprehensive unit and integration tests | Python, pytest, hypothesis |
-| **Benchmarking** | Performance profiling and optimisation | Python profiling tools, cProfile |
-| **Streaming API** | Memory-efficient chunked encryption | Python generators, async/await |
-| **Key Rotation** | Graceful cryptographic key migration | Cryptography, design patterns |
-| **Documentation** | API reference, tutorials, examples | Technical writing, Markdown |
-
-### Development Setup
-
-```bash
-# - clone repository -
-git clone https://github.com/ogkae/yurei
-cd yurei
-
-# - install development dependencies -
-pip install -e ".[dev]"
-
-# - run test suite -
-pytest tests/ -v
-
-# - run linter -
-ruff check .
-
-# - format code -
-black .
-
-# - type checking -
-mypy yurei/
-```
-
-<details>
-<summary><b><code>Contribution Workflow</code></b></summary>
-  
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-**Code Standards:**
-- Follow PEP 8 style guidelines
-- Add type hints for all public functions
-- Write docstrings for all modules, classes, and functions
-- Include unit tests for new functionality
-- Update documentation as needed
-
-</details>
-
----
-
-### Contributors
 
 <div align="center">
-  
-|[![Contributors](https://contrib.rocks/image?repo=ogkae/yurei)](https://github.com/ogkae/yurei/graphs/contributors)|
-|-|
-
-<br></br>
-
-[`↑ Back to Top`](#table-of-contents)
-
-<br></br>
-
-| Licensed under the [`MIT Licence`](./LICENSE)<br></br><a href="https://discord.com/users/1394747147106254949"><img src="https://img.shields.io/badge/Discord-000000?style=for-the-badge&logo=discord"></a><a href="https://github.com/hexa-hosting"><img src="https://img.shields.io/badge/hexaʰ-000000?style=for-the-badge&logo=github"></a> |
-|:----:|
-
+<table>
+<tr>
+<td align="center">
+  <a href="https://isocpp.org"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=cplusplus&logoColor=white"></a>
+  <a href="https://rust-lang.org"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=rust&logoColor=white"></a>
+  <a href="https://go.dev"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=go&logoColor=white"></a>
+  <a href="https://python.org"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=python&logoColor=white"></a>
+  <a href="https://typescriptlang.org"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=typescript&logoColor=white"></a>
+  <a href="https://julialang.org"><img src="https://img.shields.io/badge/%20-000000?style=flat-square&logo=julia&logoColor=white"></a>
+</td>
+<td align="center">
+  <a href="mailto:stehpenderdealer@proton.me"><code>stehpenderdealer@proton.me</code></a>
+</td>
+</tr>
+</table>
 </div>

--- a/yurei/_store_backends.py
+++ b/yurei/_store_backends.py
@@ -1,0 +1,150 @@
+"""internal backends for kv storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any
+import json
+import sqlite3
+
+_PRAGMA_JOURNAL_MODE = "WAL"
+_PRAGMA_SYNCHRONOUS = "NORMAL"
+_PRAGMA_CACHE_SIZE = -64000
+_PRAGMA_TEMP_STORE = "MEMORY"
+
+
+def _encode_value(value: Any) -> str:
+    try:
+        return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"value is not json-serializable: {exc}") from exc
+
+
+def _decode_value(value: str) -> Any:
+    return json.loads(value)
+
+
+@dataclass(slots=True)
+class InMemoryKVBackend:
+    """in-memory backend for fast ephemeral storage."""
+
+    data: dict[str, str] = field(default_factory=dict)
+    lock: RLock = field(default_factory=RLock)
+
+    def set(self, key: str, value: Any) -> None:
+        payload = _encode_value(value)
+        with self.lock:
+            self.data[key] = payload
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self.lock:
+            value = self.data.get(key)
+        return default if value is None else _decode_value(value)
+
+    def delete(self, key: str) -> bool:
+        with self.lock:
+            return self.data.pop(key, None) is not None
+
+    def exists(self, key: str) -> bool:
+        with self.lock:
+            return key in self.data
+
+    def keys(self, prefix: str | None = None) -> list[str]:
+        with self.lock:
+            key_list = list(self.data.keys())
+        if prefix:
+            key_list = [k for k in key_list if k.startswith(prefix)]
+        return sorted(key_list)
+
+    def clear(self, prefix: str | None = None) -> int:
+        with self.lock:
+            if prefix is None:
+                count = len(self.data)
+                self.data.clear()
+                return count
+
+            keys_to_delete = [k for k in self.data if k.startswith(prefix)]
+            for key in keys_to_delete:
+                del self.data[key]
+            return len(keys_to_delete)
+
+    def close(self) -> None:
+        return
+
+
+@dataclass(slots=True)
+class SQLiteKVBackend:
+    """sqlite backend for persistent storage."""
+
+    path: str
+    conn: sqlite3.Connection = field(init=False)
+    lock: RLock = field(default_factory=RLock)
+
+    def __post_init__(self) -> None:
+        self.conn = sqlite3.connect(self.path, check_same_thread=False)
+        self.conn.execute(f"PRAGMA journal_mode={_PRAGMA_JOURNAL_MODE}")
+        self.conn.execute(f"PRAGMA synchronous={_PRAGMA_SYNCHRONOUS}")
+        self.conn.execute(f"PRAGMA cache_size={_PRAGMA_CACHE_SIZE}")
+        self.conn.execute(f"PRAGMA temp_store={_PRAGMA_TEMP_STORE}")
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS kv (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def set(self, key: str, value: Any) -> None:
+        payload = _encode_value(value)
+        with self.lock:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)",
+                (key, payload),
+            )
+            self.conn.commit()
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self.lock:
+            row = self.conn.execute("SELECT value FROM kv WHERE key=?", (key,)).fetchone()
+        return default if row is None else _decode_value(row[0])
+
+    def delete(self, key: str) -> bool:
+        with self.lock:
+            cursor = self.conn.execute("DELETE FROM kv WHERE key=?", (key,))
+            self.conn.commit()
+            return cursor.rowcount > 0
+
+    def exists(self, key: str) -> bool:
+        with self.lock:
+            row = self.conn.execute("SELECT 1 FROM kv WHERE key=? LIMIT 1", (key,)).fetchone()
+        return row is not None
+
+    def keys(self, prefix: str | None = None) -> list[str]:
+        query = "SELECT key FROM kv ORDER BY key"
+        params: tuple[str, ...] = ()
+        if prefix:
+            query = "SELECT key FROM kv WHERE key LIKE ? ORDER BY key"
+            params = (f"{prefix}%",)
+
+        with self.lock:
+            rows = self.conn.execute(query, params).fetchall()
+        return [row[0] for row in rows]
+
+    def clear(self, prefix: str | None = None) -> int:
+        query = "DELETE FROM kv"
+        params: tuple[str, ...] = ()
+        if prefix:
+            query = "DELETE FROM kv WHERE key LIKE ?"
+            params = (f"{prefix}%",)
+
+        with self.lock:
+            cursor = self.conn.execute(query, params)
+            self.conn.commit()
+            return cursor.rowcount
+
+    def close(self) -> None:
+        with self.lock:
+            self.conn.close()

--- a/yurei/store.py
+++ b/yurei/store.py
@@ -1,286 +1,64 @@
-"""Simple key-value storage with SQLite or in-memory backend
+"""simple kv store with pluggable backends."""
 
-Features:
-- SQLite persistent storage with WAL mode
-- In-memory storage for temporary data
-- JSON serialization for complex values
-- Context manager support
-- Thread-safe operations
-"""
+from __future__ import annotations
 
-from typing import Any, Dict, Final, List, Optional
-import sqlite3
-import json
+from typing import Any
 
-_PRAGMA_JOURNAL_MODE: Final[str] = "WAL"
-_PRAGMA_SYNCHRONOUS: Final[str] = "NORMAL"
-_PRAGMA_CACHE_SIZE: Final[int] = -64000  # 64MB cache
-_PRAGMA_TEMP_STORE: Final[str] = "MEMORY"
+from ._store_backends import InMemoryKVBackend, SQLiteKVBackend
+
 
 class KVStore:
-    """Simple key-value store with SQLite or in-memory backend.
-    
-    Features:
-        - SQLite file storage if path provided
-        - In-memory dictionary if no path
-        - JSON serialization/deserialization
-        - Context manager support
-        - Thread-safe SQLite operations
-        
-    Example:
-        >>> # In-memory storage
-        >>> store = KVStore()
-        >>> store.set("key", {"value": "data"})
-        >>> store.get("key")
-        {'value': 'data'}
-        
-        >>> # Persistent storage
-        >>> with KVStore("data.db") as db:
-        ...     db.set("user:123", {"name": "Alice"})
-        ...     user = db.get("user:123")
-    """
+    """minimal key-value store backed by sqlite or memory."""
 
-    def __init__(self, path: Optional[str] = None) -> None:
-        """Initialize the key-value store.
-        
-        Args:
-            path: Optional path to SQLite file. If None, store is in-memory.
-        """
+    def __init__(self, path: str | None = None) -> None:
         self.path = path
-        self._conn: Optional[sqlite3.Connection] = None
-        self._data: Dict[str, str] = {}
-        
         if path:
-            self._init_sqlite()
+            self._backend = SQLiteKVBackend(path)
         else:
-            self._init_memory()
-    
-    def _init_sqlite(self) -> None:
-        """Initialize SQLite database with optimized settings."""
-        self._conn = sqlite3.connect(self.path, check_same_thread=False)
-        
-        # Apply performance optimizations
-        self._conn.execute(f"PRAGMA journal_mode={_PRAGMA_JOURNAL_MODE}")
-        self._conn.execute(f"PRAGMA synchronous={_PRAGMA_SYNCHRONOUS}")
-        self._conn.execute(f"PRAGMA cache_size={_PRAGMA_CACHE_SIZE}")
-        self._conn.execute(f"PRAGMA temp_store={_PRAGMA_TEMP_STORE}")
-        
-        # Create table
-        cursor = self._conn.cursor()
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS kv (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            )
-        """)
-        self._conn.commit()
-    
-    def _init_memory(self) -> None:
-        """Initialize in-memory storage."""
-        self._data = {}
-    
+            self._backend = InMemoryKVBackend()
+
     def set(self, key: str, value: Any) -> None:
-        """Store a key-value pair.
-        
-        Args:
-            key: The key to store.
-            value: The value to store (must be JSON-serializable).
-            
-        Raises:
-            ValueError: If key is empty.
-            TypeError: If value is not JSON-serializable.
-            
-        Example:
-            >>> store = KVStore()
-            >>> store.set("user:123", {"name": "Alice", "age": 30})
-        """
+        """store a value under a key."""
         if not key:
-            raise ValueError("Key cannot be empty")
-        
-        try:
-            payload = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
-        except (TypeError, ValueError) as e:
-            raise TypeError(f"Value is not JSON-serializable: {e}")
-        
-        if self.path:
-            cursor = self._conn.cursor()
-            cursor.execute(
-                "INSERT OR REPLACE INTO kv (key, value) VALUES (?, ?)",
-                (key, payload)
-            )
-            self._conn.commit()
-        else:
-            self._data[key] = payload
-    
+            raise ValueError("key cannot be empty")
+        self._backend.set(key, value)
+
     def get(self, key: str, default: Any = None) -> Any:
-        """Retrieve a value by key.
-        
-        Args:
-            key: The key to look up.
-            default: Default value if key not found.
-            
-        Returns:
-            The stored value, or default if not found.
-            
-        Example:
-            >>> store.set("key", {"value": "data"})
-            >>> store.get("key")
-            {'value': 'data'}
-            >>> store.get("missing", default="not found")
-            'not found'
-        """
+        """read a value from storage."""
         if not key:
             return default
-        
-        if self.path:
-            cursor = self._conn.cursor()
-            cursor.execute("SELECT value FROM kv WHERE key=?", (key,))
-            row = cursor.fetchone()
-            if row is None:
-                return default
-            return json.loads(row[0])
-        else:
-            value = self._data.get(key)
-            if value is None:
-                return default
-            return json.loads(value)
-    
+        return self._backend.get(key, default)
+
     def delete(self, key: str) -> bool:
-        """Delete a key-value pair.
-        
-        Args:
-            key: The key to delete.
-            
-        Returns:
-            True if key was deleted, False if key didn't exist.
-            
-        Example:
-            >>> store.set("key", "value")
-            >>> store.delete("key")
-            True
-            >>> store.delete("key")
-            False
-        """
+        """remove a key if present."""
         if not key:
             return False
-        
-        if self.path:
-            cursor = self._conn.cursor()
-            cursor.execute("DELETE FROM kv WHERE key=?", (key,))
-            deleted = cursor.rowcount > 0
-            self._conn.commit()
-            return deleted
-        else:
-            return self._data.pop(key, None) is not None
-    
+        return self._backend.delete(key)
+
     def exists(self, key: str) -> bool:
-        """Check if a key exists without retrieving its value.
-        
-        Args:
-            key: The key to check.
-            
-        Returns:
-            True if key exists, False otherwise.
-            
-        Example:
-            >>> store.set("key", "value")
-            >>> store.exists("key")
-            True
-            >>> store.exists("missing")
-            False
-        """
+        """check key existence without loading the value."""
         if not key:
             return False
-        
-        if self.path:
-            cursor = self._conn.cursor()
-            cursor.execute("SELECT 1 FROM kv WHERE key=? LIMIT 1", (key,))
-            return cursor.fetchone() is not None
-        else:
-            return key in self._data
-    
-    def keys(self, prefix: Optional[str] = None) -> List[str]:
-        """List all keys, optionally filtered by prefix.
-        
-        Args:
-            prefix: Optional prefix to filter keys.
-            
-        Returns:
-            List of matching keys.
-            
-        Example:
-            >>> store.set("user:1", {"name": "Alice"})
-            >>> store.set("user:2", {"name": "Bob"})
-            >>> store.set("post:1", {"title": "Hello"})
-            >>> store.keys(prefix="user:")
-            ['user:1', 'user:2']
-        """
-        if self.path:
-            cursor = self._conn.cursor()
-            if prefix:
-                cursor.execute(
-                    "SELECT key FROM kv WHERE key LIKE ? ORDER BY key",
-                    (f"{prefix}%",)
-                )
-            else:
-                cursor.execute("SELECT key FROM kv ORDER BY key")
-            return [row[0] for row in cursor.fetchall()]
-        else:
-            if prefix:
-                return sorted([k for k in self._data.keys() if k.startswith(prefix)])
-            else:
-                return sorted(self._data.keys())
-    
-    def clear(self, prefix: Optional[str] = None) -> int:
-        """Clear all keys, or keys matching a prefix.
-        
-        Args:
-            prefix: Optional prefix to filter keys for deletion.
-            
-        Returns:
-            Number of keys deleted.
-            
-        Example:
-            >>> store.clear(prefix="temp:")  # Clear temporary keys
-            5
-            >>> store.clear()  # Clear all keys
-            10
-        """
-        if self.path:
-            cursor = self._conn.cursor()
-            if prefix:
-                cursor.execute("DELETE FROM kv WHERE key LIKE ?", (f"{prefix}%",))
-            else:
-                cursor.execute("DELETE FROM kv")
-            deleted = cursor.rowcount
-            self._conn.commit()
-            return deleted
-        else:
-            if prefix:
-                keys_to_delete = [k for k in self._data.keys() if k.startswith(prefix)]
-                for key in keys_to_delete:
-                    del self._data[key]
-                return len(keys_to_delete)
-            else:
-                count = len(self._data)
-                self._data.clear()
-                return count
-    
-    def __enter__(self):
-        """Context manager entry."""
+        return self._backend.exists(key)
+
+    def keys(self, prefix: str | None = None) -> list[str]:
+        """list sorted keys, optionally filtered by prefix."""
+        return self._backend.keys(prefix)
+
+    def clear(self, prefix: str | None = None) -> int:
+        """delete all keys or all keys under a prefix."""
+        return self._backend.clear(prefix)
+
+    def close(self) -> None:
+        """close any open resources."""
+        self._backend.close()
+
+    def __enter__(self) -> "KVStore":
         return self
-    
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit - close connection."""
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         self.close()
         return False
-    
-    def close(self) -> None:
-        """Explicitly close the database connection."""
-        if self._conn:
-            self._conn.close()
-            self._conn = None
-    
-    def __del__(self):
-        """Cleanup on deletion."""
+
+    def __del__(self) -> None:
         self.close()


### PR DESCRIPTION
### Motivation
- hacer la capa de almacenamiento más escalable y modular para poder añadir backends sin romper la api pública.
- simplificar y endurecer la implementación manteniendo una api mínima y fácil de entender.
- mejorar la legibilidad y la documentación para que el proyecto sea práctico y atractivo sin exceso de texto.

### Description
- refactoriza `KVStore` para delegar en backends pluggables y minimalistas (`InMemoryKVBackend`, `SQLiteKVBackend`) ubicados en `yurei/_store_backends.py`, manteniendo la API pública (`set/get/delete/exists/keys/clear`).
- añade serialización JSON centralizada y locking con `RLock` en los backends para operaciones concurrentes y comportamiento consistente en memoria y sqlite.
- reemplaza la implementación monolítica de `yurei/store.py` por un wrapper limpio que selecciona el backend según `path` y expone la misma interfaz pública.
- rediseña `README.md` para que sea más compacto, legible y directo, con un `quick start`, tabla de módulos y explicación breve de la arquitectura modular; docstrings y comentarios simplificados en minúscula donde se introdujeron nuevos archivos.

### Testing
- compilación estática del paquete con `python -m compileall yurei` (succeeded).
- pruebas de humo ejecutadas con un script que crea y usa `KVStore` en memoria y en `/tmp/yurei_test.db` (sets/gets/exists/keys/clear/delete) and all assertions passed (smoke ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79f97484c83329a11dc24b29070b7)